### PR TITLE
Give correct path for installing from git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ From Github:
 
 ```
 > git clone https://github.com/bennn/trivial
-> raco pkg install ./trivial
+> raco pkg install ./trivial/trivial
 ```
 
 From the Racket [package server](http://pkgs.racket-lang.org/):


### PR DESCRIPTION
The top-level of the repository is not the desired package. The subdirectory with the same name is, though.

My local environment has packages installed that are duplicated by the various packages inside of the icfp-2016 folder. If I instead install the trivial subdirectory, raco pkg doesn't complain about duplicate packages and the install is fine.
