### PR TITLE
add trivial/string

### DIFF
--- a/test/regexp-pass.rkt
+++ b/test/regexp-pass.rkt
@@ -6,6 +6,7 @@
 
   (require
     trivial/regexp
+    trivial/string
     trivial/define
     typed/rackunit)
 
@@ -421,4 +422,13 @@
         (regexp-match "((a)b)" "abc")
         (U #f (List String String String)))
       '("ab" "ab" "a")))
+
+  (test-case "regexp:string"
+    (let ([s0 "a*"]
+          [s1 "b*"])
+      (check-equal?
+        (ann
+          (regexp-match (string-append "(" s0 ")" s1) "aaab")
+          (U #f (List String String)))
+        '("aaab" "aaa"))))
 )

--- a/test/string-fail.rkt
+++ b/test/string-fail.rkt
@@ -1,0 +1,31 @@
+#lang racket/base
+(require
+  trivial/private/test-common)
+
+(module+ test (test-compile-error
+  #:require trivial/string
+  #:exn #rx"out of range"
+  (string-ref "" 0)
+  (string-ref "abc" 3)
+  (string-ref "a" -1)
+  ;;(string-set! "" 0 #\x)
+  ;;(string-set! "a" 3 ((lambda (x) x) #\A)) ;; TODO not a compile-time error
+  (substring "asdf" -3)
+  (substring "asdf" 0 8)
+  (substring "asdf" 0 -1)
+  (substring "asdf" 99 3)
+
+  (bytes-ref #"" 8)
+  (bytes-ref #"aaa" -1)
+  ;;(bytes-set! #"a" 1 3)
+  ;;(bytes-set! #"a" -1 69)
+  (subbytes #"xxx" -2)
+  (subbytes #"xxx" 2 4)
+  (subbytes #"xxx" -8 -2)))
+
+(module+ test (test-compile-error
+  #:require trivial/string
+  #:exn #rx"Invalid slice range"
+  (substring "asdf" 2 1)
+  (subbytes #"asdf" 1 0)))
+

--- a/test/string-pass.rkt
+++ b/test/string-pass.rkt
@@ -1,0 +1,78 @@
+#lang typed/racket/base
+
+(module+ test
+
+  (require
+    trivial/regexp
+    trivial/string
+    trivial/define
+    trivial/integer
+    typed/rackunit)
+
+  (test-case "string"
+    (check-equal?
+      (ann (string-length "") Zero)
+      0)
+    (check-equal?
+      (ann (- (string-length "racket") 6) Zero)
+      0)
+    (check-equal?
+      (ann (string-ref "racket" 0) Char)
+      #\r)
+    #;(check-equal?
+      (let ([s (string-append "r" "acket")])
+        (check-equal? (string-set! s 0 #\R) (void))
+        0
+        #;(ann (- (string-length s) 6) Zero))
+      0)
+    (check-equal?
+      (ann (- (string-length (substring "racket" 5)) 1) Zero)
+      0)
+    (check-equal?
+      (ann (- (string-length (substring "racket" 0 3)) 3) Zero)
+      0)
+    (check-equal?
+      (ann (- (string-length (substring "racket" 3 6)) 3) Zero)
+      0)
+    (check-equal?
+      (ann (- (string-length (string-append "rac" "ke" "t")) 6) Zero)
+      0))
+
+  (test-case "bytes"
+    (check-equal?
+      (ann (- (bytes-length #"aaaa") 4) Zero)
+      0)
+    (check-equal?
+      (ann (bytes-ref #"racket" 2) Byte)
+      (char->integer #\c))
+    #;(check-equal?
+      (ann (- (bytes-length (bytes-set! (bytes-append #"" #"racket") 5 #\T)) 6) Zero)
+      0)
+    (check-equal?
+      (ann (- (bytes-length (subbytes #"racket" 2)) 4) Zero)
+      0)
+    (check-equal?
+      (ann (- (bytes-length (subbytes #"racket" 4 6)) 2) Zero)
+      0)
+    (check-equal?
+      (ann (- (bytes-length (bytes-append #"r" #"a" #"ck" #"et")) 6) Zero)
+      0))
+
+  (test-case "regexp:string"
+    (let ([s0 "a*"]
+          [s1 "b*"])
+      (check-equal?
+        (ann
+          (regexp-match (string-append "(" s0 ")" s1) "aaab")
+          (U #f (List String String)))
+        '("aaab" "aaa"))))
+
+  (test-case "regexp:bytes"
+    (let ([s0 #"a*"]
+          [s1 #"b*"])
+      (check-equal?
+        (ann
+          (regexp-match (bytes-append #"(" s0 #")" s1) #"aaab")
+          (U #f (List Bytes Bytes)))
+        '(#"aaab" #"aaa"))))
+)

--- a/trivial/main.rkt
+++ b/trivial/main.rkt
@@ -8,6 +8,7 @@ trivial/function
 trivial/list
 trivial/integer
 trivial/regexp
+trivial/string
 trivial/vector
 (only-in trivial/private/common
   [ttt-logger trivial-logger])

--- a/trivial/private/regexp.rkt
+++ b/trivial/private/regexp.rkt
@@ -28,6 +28,7 @@
     car and or list-ref let regexp-match regexp pregexp byte-regexp byte-pregexp))
   (prefix-in ttt- (only-in trivial/private/list list))
   trivial/private/tailoring
+  (only-in trivial/private/string S-dom B-dom)
   (for-syntax
     (only-in racket/syntax format-id)
     racket/base
@@ -243,7 +244,11 @@
   (define R-dom
     (make-abstract-domain R
      [x
-      (parse-groups #'x)]))
+      (let* ([φ (φ #'x)]
+             [s (φ-ref φ S-dom)])
+        (if (or (string? s) (bytes? s))
+          (parse-groups (quasisyntax/loc stx #,s))
+          (parse-groups #'x)))]))
 
 )
 

--- a/trivial/private/sequence-domain.rkt
+++ b/trivial/private/sequence-domain.rkt
@@ -59,6 +59,11 @@
   ;; Make an error message that says `i` is an invalid access to the value
   ;; in the syntax object `stx`.
 
+  format-slice-error
+  ;; (-> Syntax Integer Integer String)
+  ;; (format-slice-error stx lo hi)
+  ;; Make an error message that says `[lo,hi)` is an invalid slice range.
+
 )
 
 (require
@@ -255,6 +260,13 @@
           (syntax-line stx)
           (syntax-column stx)
           i
+          (syntax->datum stx)))
+
+(define (format-slice-error stx lo hi)
+  (format "[~a:~a] Invalid slice range [~a,~a) for '~a'"
+          (syntax-line stx)
+          (syntax-column stx)
+          lo hi
           (syntax->datum stx)))
 
 ;; =============================================================================

--- a/trivial/private/string.rkt
+++ b/trivial/private/string.rkt
@@ -1,0 +1,252 @@
+#lang racket/base
+
+;; Strings, Byte Strings, and Characters (for now, the chars should move)
+
+(provide
+  (for-syntax C-dom S-dom B-dom)
+  (rename-out
+   [-string-length string-length]
+   [-string-ref string-ref]
+   #;[-string-set! string-set!]
+   [-substring substring]
+   [-string-append string-append]
+   [-bytes-length bytes-length]
+   [-bytes-ref bytes-ref]
+   #;[-bytes-set! bytes-set!]
+   [-subbytes subbytes]
+   [-bytes-append bytes-append]))
+
+;; -----------------------------------------------------------------------------
+
+(require
+  syntax/parse
+  trivial/private/tailoring
+  (only-in trivial/private/integer
+    I-dom)
+  (prefix-in τ- (only-in typed/racket/base
+    string-length
+    string-ref
+    string-set!
+    substring
+    string-append
+    ;; ---
+    bytes-length
+    bytes-ref
+    bytes-set!
+    subbytes
+    bytes-append))
+  (prefix-in λ- (only-in racket/base
+    string-length
+    string-ref
+    string-set!
+    substring
+    string-append
+    ;; ---
+    bytes-length
+    bytes-ref
+    bytes-set!
+    subbytes
+    bytes-append))
+  (for-syntax
+    syntax/parse
+    racket/syntax
+    racket/base
+    trivial/private/common
+    (only-in trivial/private/sequence-domain
+      format-bounds-error
+      format-slice-error)))
+
+;; =============================================================================
+
+(define-for-syntax C-dom
+  (make-abstract-domain C
+   [c:char
+    (syntax-e #'c)]))
+
+;; -----------------------------------------------------------------------------
+
+(define-for-syntax S-dom
+  (make-abstract-domain S
+   [s:str
+    (syntax-e #'s)]))
+
+(define-tailoring (-string-length [e ~> e+ (φ [S-dom ↦ s])])
+  #:with +string-length (τλ #'τ-string-length #'λ-string-length)
+  #:= (⊥? S-dom s)
+      (+string-length e+)
+  #:+ #t
+      '#,(string-length s)
+  #:φ (φ-set (φ-init) I-dom (if (⊥? S-dom s) (⊥ I-dom) (string-length s))))
+
+(define-tailoring (-string-ref [e0 ~> e0+ (φ0 [S-dom ↦ s])] [e1 ~> e1+ (φ1 [I-dom ↦ k])])
+  #:with +string-ref (τλ #'τ-string-ref #'λ-string-ref)
+  (define any-bot? (or (⊥? S-dom s) (⊥? I-dom k)))
+  #:= any-bot?
+      (+string-ref e0+ e1+)
+  #:+ (and (<= 0 k) (< k (string-length s)))
+      '#,(string-ref s k)
+  #:- #true
+      (format-bounds-error #'e0+ k)
+  #:φ (φ-set (φ-init) C-dom (if any-bot? (⊥ C-dom) (string-ref s k))))
+
+(define-tailoring (-string-set! [e0 ~> e0+ (φ0 [S-dom ↦ s])] [e1 ~> e1+ (φ1 [I-dom ↦ k])] [e2 ~> e2+ (φ2 [C-dom ↦ c])])
+  #:with +string-set! (τλ #'τ-string-set! #'λ-string-set!)
+  (define any-bot? (or (⊥? S-dom s) (⊥? I-dom k) (⊥? C-dom c)))
+  (define safe? (and (<= 0 k) (< k (string-length s))))
+  (define str+
+    (if (or any-bot? (not safe?))
+      (⊥ S-dom)
+      (string-append (substring s 0 k) (string c) (substring s (+ k 1)))))
+  #:= any-bot?
+      (+string-set! e0+ e1+ e2+)
+  #:+ safe?
+      (+string-set! e0+ e1+ e2+)
+  #:- #true
+      (format-bounds-error #'e0+ k)
+  #:φ (φ-set (φ-init) S-dom (if any-bot? (⊥ S-dom) str+)))
+
+(define-tailoring (-substring1 [e0 ~> e0+ (φ0 [S-dom ↦ s])] [e1 ~> e1+ (φ1 [I-dom ↦ i])])
+  #:with +substring (τλ #'τ-substring #'λ-substring)
+  (define any-bot? (or (⊥? S-dom s) (⊥? I-dom i)))
+  #:= any-bot?
+      (+substring e0+ e1+)
+  #:+ (and (<= 0 i) (< i (string-length s)))
+      '#,(substring s i)
+  #:- #true
+      (format-bounds-error #'e0+ i)
+  #:φ (φ-set (φ-init) S-dom (if any-bot? (⊥ S-dom) (substring s i))))
+
+(define-tailoring (-substring2 [e0 ~> e0+ (φ0 [S-dom ↦ s])] [e1 ~> e1+ (φ1 [I-dom ↦ i1])] [e2 ~> e2+ (φ2 [I-dom ↦ i2])])
+  #:with +substring (τλ #'τ-substring #'λ-substring)
+  (define any-bot? (or (⊥? S-dom s) (⊥? I-dom i1) (⊥? I-dom i2)))
+  #:= any-bot?
+      (+substring e0+ e1+ e2+)
+  #:+ (and (<= 0 i1) (<= i1 i2) (<= i2 (string-length s)))
+      '#,(substring s i1 i2)
+  #:- #true
+      (cond
+       [(or (< i1 0) (<= (string-length s) i1))
+        (format-bounds-error #'e0+ i1)]
+       [(or (< i2 0) (< (string-length s) i2))
+        (format-bounds-error #'e0+ i2)]
+       [else
+        (format-slice-error #'e0+ i1 i2)])
+  #:φ (φ-set (φ-init) S-dom (if any-bot? (⊥ S-dom) (substring s i1 i2))))
+
+(define-syntax (-substring stx)
+  (syntax-parse stx
+   [(_ e0 e1)
+    (syntax/loc stx (-substring1 e0 e1))]
+   [(_ . e*)
+    (syntax/loc stx (-substring2 . e*))]
+   [_:id
+    (syntax/loc stx -substring2)]))
+
+(define-tailoring (-string-append [e* ~> e+* (φ [S-dom ↦ s*])] ...)
+  #:with +string-append (τλ #'τ-string-append #'λ-string-append)
+  #:= (for/or ([s (in-list s*)])
+        (⊥? S-dom s))
+      (+string-append e+* ...)
+  #:+ #t
+      '#,(apply string-append s*)
+  #:φ (φ-set (φ-init) S-dom (reduce* S-dom string-append "" s*)))
+
+;; -----------------------------------------------------------------------------
+
+(define-for-syntax B-dom
+  (make-abstract-domain B
+   [b
+    (let ([v (syntax-e #'b)])
+      (and (bytes? v) v))]))
+
+(define-for-syntax (format-bytes-error stx)
+  (format "[~a:~a] expected a byte in '~a'"
+          (syntax-source stx)
+          (syntax-line stx)
+          (syntax->datum stx)))
+
+(define-tailoring (-bytes-length [e ~> e+ (φ [B-dom ↦ b])])
+  #:with +bytes-length (τλ #'τ-bytes-length #'λ-bytes-length)
+  #:= (⊥? B-dom b)
+      (+bytes-length e+)
+  #:+ #t
+      '#,(bytes-length b)
+  #:φ (φ-set (φ-init) I-dom (if (⊥? B-dom b) (⊥ I-dom) (bytes-length b))))
+
+(define-tailoring (-bytes-ref [e0 ~> e0+ (φ0 [B-dom ↦ b])] [e1 ~> e1+ (φ1 [I-dom ↦ k])])
+  #:with +bytes-ref (τλ #'τ-bytes-ref #'λ-bytes-ref)
+  (define any-bot? (or (⊥? B-dom b) (⊥? I-dom k)))
+  #:= any-bot?
+      (+bytes-ref e0+ e1+)
+  #:+ (and (<= 0 k) (< k (bytes-length b)))
+      '#,(bytes-ref b k)
+  #:- #true
+      (format-bounds-error #'e0+ k)
+  #:φ (φ-set (φ-init) I-dom (if any-bot? (⊥ I-dom) (bytes-ref b k))))
+
+(define-tailoring (-bytes-set! [e0 ~> e0+ (φ0 [B-dom ↦ b])] [e1 ~> e1+ (φ1 [I-dom ↦ k])] [e2 ~> e2+ (φ2 [I-dom ↦ i])])
+  #:with +bytes-set! (τλ #'τ-bytes-set! #'λ-bytes-set!)
+  (define any-bot? (or (⊥? B-dom b) (⊥? I-dom k) (⊥? I-dom i)))
+  (define safe? (and (<= 0 k) (< k (bytes-length b)) (<= 0 i 256)))
+  (define bytes+
+    (if (or any-bot? (not safe?))
+      (⊥ B-dom)
+      (bytes-append (subbytes b 0 k) (bytes i) (subbytes b (+ k 1)))))
+  #:= any-bot?
+      (+bytes-set! e0+ e1+ e2+)
+  #:+ safe?
+      '#,bytes+
+  #:- #true
+      (cond
+       [(or (< k 0) (<= (bytes-length b) k))
+        (format-bounds-error #'e0+ k)]
+       [else
+        (format-bytes-error #'e2+ i)])
+  #:φ (φ-set (φ-init) B-dom (if any-bot? (⊥ B-dom) bytes+)))
+
+(define-tailoring (-subbytes1 [e0 ~> e0+ (φ0 [B-dom ↦ b])] [e1 ~> e1+ (φ1 [I-dom ↦ i])])
+  #:with +subbytes (τλ #'τ-subbytes #'λ-subbytes)
+  (define any-bot? (or (⊥? B-dom b) (⊥? I-dom i)))
+  #:= any-bot?
+      (+subbytes e0+ e1+)
+  #:+ (and (<= 0 i) (< i (bytes-length b)))
+      '#,(subbytes b i)
+  #:- #true
+      (format-bounds-error #'e0+ i)
+  #:φ (φ-set (φ-init) B-dom (if any-bot? (⊥ B-dom) (subbytes b i))))
+
+(define-tailoring (-subbytes2 [e0 ~> e0+ (φ0 [B-dom ↦ b])] [e1 ~> e1+ (φ1 [I-dom ↦ i1])] [e2 ~> e2+ (φ2 [I-dom ↦ i2])])
+  #:with +subbytes (τλ #'τ-subbytes #'λ-subbytes)
+  (define any-bot? (or (⊥? B-dom b) (⊥? I-dom i1) (⊥? I-dom i2)))
+  #:= any-bot?
+      (+subbytes e0+ e1+ e2+)
+  #:+ (and (<= 0 i1) (<= i1 i2) (<= i2 (bytes-length b)))
+      '#,(subbytes b i1 i2)
+  #:- #true
+      (cond
+       [(or (< i1 0) (<= (bytes-length b) i1))
+        (format-bounds-error #'e0+ i1)]
+       [(or (< i2 0) (< (bytes-length b) i2))
+        (format-bounds-error #'e0+ i2)]
+       [else
+        (format-slice-error #'e0+ i1 i2)])
+  #:φ (φ-set (φ-init) B-dom (if any-bot? (⊥ B-dom) (subbytes b i1 i2))))
+
+(define-syntax (-subbytes stx)
+  (syntax-parse stx
+   [(_ e0 e1)
+    (syntax/loc stx (-subbytes1 e0 e1))]
+   [(_ . e*)
+    (syntax/loc stx (-subbytes2 . e*))]
+   [_:id
+    (syntax/loc stx -subbytes2)]))
+
+(define-tailoring (-bytes-append [e* ~> e+* (φ [B-dom ↦ b*])] ...)
+  #:with +bytes-append (τλ #'τ-bytes-append #'λ-bytes-append)
+  #:= (for/or ([b (in-list b*)])
+        (⊥? B-dom b))
+      (+bytes-append e+* ...)
+  #:+ #t
+      '#,(apply bytes-append b*)
+  #:φ (φ-set (φ-init) B-dom (reduce* B-dom bytes-append #"" b*)))
+

--- a/trivial/scribblings/using-tailorings.scrbl
+++ b/trivial/scribblings/using-tailorings.scrbl
@@ -174,6 +174,27 @@ Do not @racket[set!] in a module that uses @racket[trivial/define].
   ]
 }
 
+@defmodule[trivial/string]
+
+@deftogether[(
+  @defproc[(string-length [str string?]) exact-nonnegative-integer?]{}
+  @defproc[(string-ref [str string?] [k exact-nonnegative-integer?]) char?]{}
+  @defproc[(substring [str string?] [start exact-nonnegative-integer?] [end exact-nonnegative-integer? (string-length str)]) string?]{}
+  @defproc[(string-append [str string?] ...) string?]{}
+)]
+@deftogether[(
+  @defproc[(bytes-length [bstr bytes?]) exact-nonnegative-integer?]{}
+  @defproc[(bytes-ref [bstr bytes?] [k exact-nonnegative-integer?]) byte?]{}
+  @defproc[(subbytes [bstr bytes?] [start exact-nonnegative-integer?] [end exact-nonnegative-integer? (bytes-length bstr)]) bytes?]{}
+  @defproc[(bytes-append [bstr bytes?] ...) bytes?]{}
+)]{
+  String and byte string operations that track the value of their arguments.
+
+  @examples[#:eval (make-typed-eval)
+    (regexp-match (string-append "(" "a*" ")") "aaa")
+  ]
+}
+
 
 @defmodule[trivial/vector]
 

--- a/trivial/string.rkt
+++ b/trivial/string.rkt
@@ -1,0 +1,5 @@
+#lang reprovide
+
+(except-in trivial/private/string
+  B-dom S-dom)
+


### PR DESCRIPTION
Implement value-tracking string functions,
specifically to enable `string-append` for building `regexp-match` patterns.